### PR TITLE
Fix support for browsers

### DIFF
--- a/lib/remote-connector.js
+++ b/lib/remote-connector.js
@@ -49,7 +49,7 @@ RemoteConnector.initialize = function(dataSource, callback) {
   var connector = dataSource.connector =
     new RemoteConnector(dataSource.settings);
   connector.connect();
-  setImmediate(callback);
+  process.nextTick(callback);
 };
 
 RemoteConnector.prototype.define = function(definition) {


### PR DESCRIPTION
Use `process.nextTick` instead of `setImmediate`, as the latter is
not a standard API.

https://developer.mozilla.org/en-US/docs/Web/API/Window.setImmediate

/to @kraman please review
/cc @ritch 
