### PR TITLE
Fix failing tests on CI

### DIFF
--- a/test/remote-connector.test.js
+++ b/test/remote-connector.test.js
@@ -13,7 +13,7 @@ describe('RemoteConnector', function() {
       remoteApp.use(loopback.rest());
       remoteApp.listen(0, function() {
         test.dataSource = loopback.createDataSource({
-          host: remoteApp.get('host'),
+          host: '127.0.0.1',
           port: remoteApp.get('port'),
           connector: loopback.Remote
         });
@@ -40,7 +40,7 @@ describe('RemoteConnector', function() {
 
     remoteApp.listen(0, function() {
       test.remote = loopback.createDataSource({
-        host: remoteApp.get('host'),
+        host: '127.0.0.1',
         port: remoteApp.get('port'),
         connector: loopback.Remote
       });


### PR DESCRIPTION
test: specify 127.0.0.1 for test server

Without this the client may attempt to connect to 'localhost' which may
resolve to the IPv6 equivalent of '0.0.0.0', which is '::', which is
only useful listening on and not so useful for connecting too.