### PR TITLE
Register Models with Dynamic converter

### DIFF
--- a/lib/remote-connector.js
+++ b/lib/remote-connector.js
@@ -40,7 +40,7 @@ function RemoteConnector(settings) {
   // handle mixins in the define() method
   var DAO = this.DataAccessObject = function() {
   };
-  
+
 }
 
 RemoteConnector.prototype.connect = function() {
@@ -76,6 +76,11 @@ RemoteConnector.prototype.resolve = function(Model) {
     if (remoteMethod.name !== 'Change' && remoteMethod.name !== 'Checkpoint') {
       createProxyMethod(Model, remotes, remoteMethod);
     }
+  });
+
+  // setup a remoting type converter for this model
+  remotes.defineType(Model.modelName, function(val) {
+    return val ? new Model(val) : val;
   });
 };
 


### PR DESCRIPTION
Fix `RemoteConnector.prototype.resolve` to register new models with strong-remoting's `Dynamic` type resolver.

Before this change, if loopback-connector-remoting ended up with its own copy of strong-remoting, then the responses were not converted from plain objects to model instances, because model converters were registered with the other instances of strong-remoting.

This has a side-effect that when there is only one strong-remoting instance in the app, then there will be multiple converters registered for the same model. Since the code performing conversion takes into account the first model only, this should not pose any issues.

Fix #34

/to @ritch @kraman please review