### PR TITLE
Use the new API for defining remoting types

### DIFF
--- a/lib/remote-connector.js
+++ b/lib/remote-connector.js
@@ -87,8 +87,8 @@ RemoteConnector.prototype.resolve = function(Model) {
   });
 
   // setup a remoting type converter for this model
-  remotes.defineType(Model.modelName, function(val) {
-    return val ? new Model(val) : val;
+  remotes.defineObjectType(Model.modelName, function(data) {
+    return new Model(data);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "http://loopback.io",
   "dependencies": {
     "loopback-datasource-juggler": "^3.0.0-alpha.7",
-    "strong-remoting": "^3.0.0-alpha.5"
+    "strong-remoting": "^3.0.0-alpha.6"
   },
   "devDependencies": {
     "assert": "^1.1.2",


### PR DESCRIPTION
A follow-up for https://github.com/strongloop/strong-remoting/pull/343, which dropped `Dynamic` and related APIs.

@gunjpan please review
cc @richardpringle 

Requires https://github.com/strongloop/strong-remoting/pull/343

Connect to strongloop-internal/scrum-loopback#974
Connect to strongloop-internal/scrum-loopback#885


**TODO before merging**
 - [x] wait for https://github.com/strongloop/strong-remoting/pull/343 to be landed
 - [x] make a new alpha release of strong-remoting
 - [x] bump up minimum version of strong-remoting dependency

