### PR TITLE
Bump up minimal loopback version in devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "grunt-cli": "^1.2.0",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-mocha-test": "^0.12.7",
-    "loopback": "^3.0.0-alpha.3",
+    "loopback": "^3.0.0-alpha.4",
     "mocha": "^3.0.2",
     "strong-task-emitter": "^0.0.7"
   },


### PR DESCRIPTION
We need the version of LoopBack that uses the new TypeRegitry API.

This is a follow-up for #58.
Connect to strongloop-internal/scrum-loopback#974
Connect to strongloop-internal/scrum-loopback#885