### PR TITLE
Add "options" arg to stubbed models in tests

### DIFF
--- a/test/remote-connector.test.js
+++ b/test/remote-connector.test.js
@@ -41,7 +41,13 @@ describe('RemoteConnector', function() {
   it('should support the save method', function(done) {
     var calledServerCreate = false;
 
-    ctx.ServerModel.create = function(data, cb, callback) {
+    ctx.ServerModel.create = function(data, options, cb, callback) {
+      if (typeof options === 'function') {
+        callback = cb;
+        cb = options;
+        options = {};
+      }
+
       calledServerCreate = true;
       data.id = 1;
       if (callback) callback(null, data);
@@ -61,7 +67,12 @@ describe('RemoteConnector', function() {
   it('should support aliases', function(done) {
     var calledServerUpsert = false;
     ctx.ServerModel.patchOrCreate =
-    ctx.ServerModel.upsert = function(id, cb) {
+    ctx.ServerModel.upsert = function(id, options, cb) {
+      if (typeof options === 'function') {
+        cb = options;
+        options = {};
+      }
+
       calledServerUpsert = true;
       cb();
     };


### PR DESCRIPTION
Fix test stubs to use correct remote-method signature matching the actual arguments of real PersistedModel methods.

This fix is required for https://github.com/strongloop/loopback/pull/3023.