### PR TITLE
Add support for configuring remoting options

### DIFF
--- a/lib/remote-connector.js
+++ b/lib/remote-connector.js
@@ -29,14 +29,14 @@ module.exports = RemoteConnector;
 function RemoteConnector(settings) {
   assert(typeof settings ===
     'object',
-    'cannot initiaze RemoteConnector without a settings object');
+    'cannot initialize RemoteConnector without a settings object');
   this.client = settings.client;
   this.adapter = settings.adapter || 'rest';
   this.protocol = settings.protocol || 'http';
   this.root = settings.root || '';
   this.host = settings.host || 'localhost';
   this.port = settings.port || 3000;
-  this.remotes = remoting.create();
+  this.remotes = remoting.create(settings.options);
   this.name = 'remote-connector';
 
   if (settings.url) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -12,6 +12,7 @@ var remoteConnector = require('..');
 exports.createMemoryDataSource = createMemoryDataSource;
 exports.createModel = createModel;
 exports.createRemoteDataSource = createRemoteDataSource;
+exports.createRemoteDataSourceWithOptions = createRemoteDataSourceWithOptions;
 exports.createRestAppAndListen = createRestAppAndListen;
 exports.getUserProperties = getUserProperties;
 
@@ -41,6 +42,14 @@ function createRemoteDataSource(remoteApp) {
   return loopback.createDataSource({
     url: 'http://' + remoteApp.get('host') + ':' + remoteApp.get('port'),
     connector: remoteConnector
+  });
+}
+
+function createRemoteDataSourceWithOptions(remoteApp, options) {
+  return loopback.createDataSource({
+    url: 'http://anyURL.com',
+    connector: remoteConnector,
+    options: options
   });
 }
 

--- a/test/remote-connector.test.js
+++ b/test/remote-connector.test.js
@@ -134,3 +134,15 @@ describe('Custom Path', function() {
     });
   });
 });
+
+describe('RemoteConnector with options', () => {
+  it('should have the remoting options passed to the remote object', () => {
+    const serverApp = helper.createRestAppAndListen();
+
+    const datasource = helper.createRemoteDataSourceWithOptions(
+      serverApp,
+      {'test': 'abc'});
+
+    assert.deepEqual(datasource.connector.remotes.options, {test: 'abc'});
+  });
+});


### PR DESCRIPTION
### Description
Allow options defined in the Remote datasource to be passed through to the connector on creation. This allows for options such as passAccessToken to be set, which will pass the loopback access token on through a remote connector to another remote loopback server.

```
  "remote-service": {
    "url": "http://localhost:3340/api",
    "name": "remote-service",
    "connector": "remote",
    "options": {
      "passAccessToken": true
    }
  },

```
#### Related issues

- connect to strongloop/strong-remoting#421
- https://github.com/strongloop/strong-remoting/pull/430

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
