### PR TITLE
Support retrieved related models from remote loopback service

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,7 +49,6 @@ module.exports = function(grunt) {
 
   // These plugins provide necessary tasks.
   grunt.loadNpmTasks('grunt-mocha-test');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
 
   // Default task.
   grunt.registerTask('default', ['unit', 'integration']);

--- a/lib/relations.js
+++ b/lib/relations.js
@@ -211,10 +211,23 @@ RelationMixin.embedsMany = function embedsMany(modelTo, params) {
 function defineRelationProperty(modelClass, def) {
   Object.defineProperty(modelClass.prototype, def.name, {
     get: function() {
-      var that = this;
-      var scope = function() {
-        return that['__get__' + def.name].apply(that, arguments);
+      const that = this;
+      const scope = function() {
+        const cachedEntities = that.__cachedRelations &&
+          that.__cachedRelations[def.name];
+
+        if (arguments.length || !cachedEntities) {
+          return that['__get__' + def.name].apply(that, arguments);
+        }
+
+        // return the cached data
+        if (Array.isArray(cachedEntities)) {
+          return cachedEntities.map(data => new def.modelTo(data));
+        } else {
+          return new def.modelTo(cachedEntities);
+        }
       };
+
       scope.count = function() {
         return that['__count__' + def.name].apply(that, arguments);
       };

--- a/lib/remote-connector.js
+++ b/lib/remote-connector.js
@@ -87,7 +87,17 @@ RemoteConnector.prototype.resolve = function(Model) {
 
   // setup a remoting type converter for this model
   remotes.defineObjectType(Model.modelName, function(data) {
-    return new Model(data);
+    const model = new Model(data);
+
+    // process cached relations
+    if (model.__cachedRelations) {
+      for (const relation in model.__cachedRelations) {
+        const relatedModel = model.__cachedRelations[relation];
+        model.__data[relation] = relatedModel;
+      }
+    }
+
+    return model;
   });
 };
 


### PR DESCRIPTION
### Description
When the remote service contacted supports include queries and the result is sent to the connector, it stored the related models data in its `__cachedRelations` property and disregards when sending to the source of the request. Now proper functionality is supported where the model is properly populated with its requested relations.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <https://github.com/strongloop/loopback-connector-remote/issues/42>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
