### PR TITLE
Fix duplicate definition of a remote model type

### DIFF
--- a/lib/remote-connector.js
+++ b/lib/remote-connector.js
@@ -62,8 +62,8 @@ RemoteConnector.initialize = function(dataSource, callback) {
 };
 
 RemoteConnector.prototype.define = function(definition) {
-  var Model = definition.model;
-  var remotes = this.remotes;
+  const Model = definition.model;
+  const remotes = this.remotes;
 
   assert(Model.sharedClass,
     'cannot attach ' +
@@ -73,17 +73,23 @@ RemoteConnector.prototype.define = function(definition) {
   jutil.mixin(Model, RelationMixin);
   jutil.mixin(Model, InclusionMixin);
   remotes.addClass(Model.sharedClass);
+
   this.resolve(Model);
+  this.setupRemotingTypeFor(Model);
 };
 
 RemoteConnector.prototype.resolve = function(Model) {
-  var remotes = this.remotes;
+  const remotes = this.remotes;
 
   Model.sharedClass.methods().forEach(function(remoteMethod) {
     if (remoteMethod.name !== 'Change' && remoteMethod.name !== 'Checkpoint') {
       createProxyMethod(Model, remotes, remoteMethod);
     }
   });
+};
+
+RemoteConnector.prototype.setupRemotingTypeFor = function(Model) {
+  const remotes = this.remotes;
 
   // setup a remoting type converter for this model
   remotes.defineObjectType(Model.modelName, function(data) {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "grunt-mocha-test": "^0.12.7",
     "loopback": "^3.0.0",
     "mocha": "^3.0.2",
+    "sinon": "^4.1.3",
     "strong-task-emitter": "^0.0.7"
   },
   "optionalDependencies": {}

--- a/test/models-define-type.test.js
+++ b/test/models-define-type.test.js
@@ -1,0 +1,74 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: loopback-connector-remote
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const helper = require('./helper');
+const loopback = require('loopback');
+const sinon = require('sinon');
+
+const relation = require('loopback-datasource-juggler/lib/relation-definition');
+const RelationTypes = relation.RelationTypes;
+
+describe('Models Define Type Tests', function() {
+  let serverApp, clientApp, remoteDs, defineObjectTypeSpy, ChildModel;
+
+  beforeEach('create remote datasource', () => {
+    serverApp = helper.createRestAppAndListen();
+    clientApp = loopback({localRegistry: true});
+    remoteDs = helper.createRemoteDataSource(clientApp, serverApp);
+  });
+
+  beforeEach('spy remote connector', () => {
+    defineObjectTypeSpy = sinon.spy(remoteDs.connector.remotes,
+      'defineObjectType');
+  });
+
+  afterEach('restore remote connector', () => {
+    defineObjectTypeSpy.restore();
+  });
+
+  it('should define a type of a remote model only once (no relations)', () => {
+    const RemoteModel = clientApp.registry.createModel({
+      name: 'RemoteModel',
+    });
+    clientApp.model(RemoteModel, {dataSource: remoteDs});
+
+    sinon.assert.calledOnce(defineObjectTypeSpy.withArgs(
+      RemoteModel.modelName));
+  });
+
+  describe('when a child model is created', () => {
+    beforeEach('create a child model', () => {
+      ChildModel = clientApp.registry.createModel({
+        name: 'ChildModel',
+      });
+      clientApp.model(ChildModel, {dataSource: remoteDs});
+    });
+
+    Object.getOwnPropertyNames(RelationTypes).forEach((relationKey) => {
+      const relation = RelationTypes[relationKey];
+
+      it('should define a type of a remote model only once (' + relation + ')',
+        () => {
+          const RemoteModel = clientApp.registry.createModel({
+            name: 'RemoteModel' + relation,
+            relations: {
+              children: {
+                type: relation,
+                model: 'ChildModel',
+              },
+            },
+          });
+          clientApp.model(RemoteModel, {dataSource: remoteDs});
+
+          sinon.assert.calledOnce(defineObjectTypeSpy.withArgs(
+            RemoteModel.modelName));
+          sinon.assert.calledOnce(defineObjectTypeSpy.withArgs(
+            ChildModel.modelName));
+        });
+    });
+  });
+});


### PR DESCRIPTION
### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #81
- see also the previous attempt in #83

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

  