### PR TITLE
Move eslint dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,6 @@
   },
   "homepage": "http://loopback.io",
   "dependencies": {
-    "eslint": "^4.13.0",
-    "eslint-config-loopback": "^10.0.0",
     "loopback-datasource-juggler": "^3.0.0",
     "strong-remoting": "^3.0.0"
   },
@@ -42,6 +40,8 @@
     "grunt": "^1.0.3",
     "grunt-cli": "^1.2.0",
     "grunt-mocha-test": "^0.13.3",
+    "eslint": "^4.13.0",
+    "eslint-config-loopback": "^10.0.0",
     "loopback": "^3.0.0",
     "mocha": "^5.2.0",
     "sinon": "^6.0.0",


### PR DESCRIPTION
### Description

Small change - Move eslint dependencies to devDependencies as consumers will pull in eslint and eslint-config-loopback

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #86

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
