### PR TITLE
Catch error and return null when find/findOne doesn't find an entity

### DIFF
--- a/lib/remote-connector.js
+++ b/lib/remote-connector.js
@@ -16,6 +16,8 @@ var jutil = require('loopback-datasource-juggler/lib/jutil');
 var RelationMixin = require('./relations');
 var InclusionMixin = require('loopback-datasource-juggler/lib/include');
 
+var findMethodNames = ['find', 'findOne'];
+
 /**
  * Export the RemoteConnector class.
  */
@@ -120,6 +122,11 @@ function createProxyMethod(Model, remotes, remoteMethod) {
     } else {
       callback = utils.createPromiseCallback();
     }
+    var callbackPromise = callback.promise;
+
+    if (findMethodNames.includes(remoteMethod.name)) {
+      callback = proxy404toNull(callback);
+    }
 
     if (remoteMethod.isStatic) {
       remotes.invoke(remoteMethod.stringName, args, callback);
@@ -128,7 +135,17 @@ function createProxyMethod(Model, remotes, remoteMethod) {
       remotes.invoke(remoteMethod.stringName, ctorArgs, args, callback);
     }
 
-    return callback.promise;
+    return callbackPromise;
+  }
+
+  function proxy404toNull(cb) {
+    return function(err, data) {
+      if (err && err.code === 'MODEL_NOT_FOUND') {
+        cb(null, {});
+        return;
+      }
+      cb(err, data);
+    };
   }
 
   scope[remoteMethod.name] = remoteMethodProxy;


### PR DESCRIPTION
### Description

When calling `findOne` or `find` on an Model which doesn't have an entity, the default behaviour on loopback is to return `null`. When calling these methods on a Model that uses a remote, it does not return `null` but rejects the Promise. To adjust these to the official loopback models the callback is wrapped in this case to return null on `model_not_found` error.  


#### Related issues

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
