### PR TITLE
Catch error and return null when findById/findOne doesn't find an entity

### DIFF
--- a/lib/remote-connector.js
+++ b/lib/remote-connector.js
@@ -16,6 +16,8 @@ var jutil = require('loopback-datasource-juggler/lib/jutil');
 var RelationMixin = require('./relations');
 var InclusionMixin = require('loopback-datasource-juggler/lib/include');
 
+var findMethodNames = ['findById', 'findOne'];
+
 /**
  * Export the RemoteConnector class.
  */
@@ -120,6 +122,11 @@ function createProxyMethod(Model, remotes, remoteMethod) {
     } else {
       callback = utils.createPromiseCallback();
     }
+    var callbackPromise = callback.promise;
+
+    if (findMethodNames.includes(remoteMethod.name)) {
+      callback = proxy404toNull(callback);
+    }
 
     if (remoteMethod.isStatic) {
       remotes.invoke(remoteMethod.stringName, args, callback);
@@ -128,7 +135,17 @@ function createProxyMethod(Model, remotes, remoteMethod) {
       remotes.invoke(remoteMethod.stringName, ctorArgs, args, callback);
     }
 
-    return callback.promise;
+    return callbackPromise;
+  }
+
+  function proxy404toNull(cb) {
+    return function(err, data) {
+      if (err && err.code === 'MODEL_NOT_FOUND') {
+        cb(null, null);
+        return;
+      }
+      cb(err, data);
+    };
   }
 
   scope[remoteMethod.name] = remoteMethodProxy;

--- a/test/remote-models.test.js
+++ b/test/remote-models.test.js
@@ -191,9 +191,8 @@ describe('Remote model tests', function() {
           ClientModel.deleteById(user.id, function(err) {
             if (err) return done(err);
             ClientModel.findById(user.id, function(err, notFound) {
+              if (err) return done(err);
               assert.equal(notFound, null);
-              assert(err && err.statusCode === 404,
-                'should have failed with HTTP 404');
               done();
             });
           });
@@ -202,6 +201,15 @@ describe('Remote model tests', function() {
   });
 
   describe('Model.findById(id, callback)', function() {
+    it('should return null when an instance does not exist',
+      function(done) {
+        ClientModel.findById(23, function(err, notFound) {
+          if (err) return done(err);
+          assert.equal(notFound, null);
+          done();
+        });
+      });
+
     it('should find an instance by id from the attached data source',
       function(done) {
         ServerModel.create({first: 'michael', last: 'jordan', id: 23},
@@ -212,6 +220,32 @@ describe('Remote model tests', function() {
               assert.equal(user.id, 23);
               assert.equal(user.first, 'michael');
               assert.equal(user.last, 'jordan');
+              done();
+            });
+          });
+      });
+  });
+
+  describe('Model.findOne([filter], callback)', function() {
+    it('should return null when an instance does not exist',
+      function(done) {
+        ClientModel.findOne({where: {id: 24}}, function(err, notFound) {
+          if (err) return done(err);
+          assert.equal(notFound, null);
+          done();
+        });
+      });
+
+    it('should find an instance from the attached data source',
+      function(done) {
+        ServerModel.create({first: 'keanu', last: 'reeves', id: 24},
+          function(err) {
+            if (err) return done(err);
+            ClientModel.findOne({where: {id: 24}}, function(err, user) {
+              if (err) return done(err);
+              assert.equal(user.id, 24);
+              assert.equal(user.first, 'keanu');
+              assert.equal(user.last, 'reeves');
               done();
             });
           });


### PR DESCRIPTION
### Description

When calling `findOne` or `findById` on an Model which doesn't have an entity, the default behaviour on loopback is to return `null`. When calling these methods on a Model that uses a remote, it does not return `null` but rejects the Promise. To adjust these to the official loopback models the callback is wrapped in this case to return null on `model_not_found` error.

**The description and basic code was taken from #91. Thank you, @joetjengerdes, to raise the problem**

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #91 

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
