### PR TITLE
Add tests to check Model.exists() working

### DIFF
--- a/test/remote-models.test.js
+++ b/test/remote-models.test.js
@@ -200,6 +200,29 @@ describe('Remote model tests', function() {
       });
   });
 
+  describe('Model.exists(id, callback)', function() {
+    it('should return true when the model with the given id exists',
+      function(done) {
+        ServerModel.create({first: 'max'}, function(err, user) {
+          if (err) return done(err);
+          ClientModel.exists(user.id, function(err, exist) {
+            if (err) return done(err);
+            assert.equal(exist, true);
+            done();
+          });
+        });
+      });
+
+    it('should return false when there is no model with the given id',
+      function(done) {
+        ClientModel.exists('user-id-does-not-exist', function(err, exist) {
+          if (err) return done(err);
+          assert.equal(exist, false);
+          done();
+        });
+      });
+  });
+
   describe('Model.findById(id, callback)', function() {
     it('should return null when an instance does not exist',
       function(done) {


### PR DESCRIPTION
### Description
The `GET /Models/:id/exists` service doesn't work for remote connector. It proxies to `GET /Models/:id/exists?id=${id}` endpoint except the required

**This PR contains only tests. It requires related PR merge and upgrade loopback dependency to stabilize**

#### Related issues


<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback/pull/4120

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
