### PR TITLE
Drop support for Node.js 6 and add Node.js 12 to CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ language: node_js
 node_js:
   - "8"
   - "10"
+  - "12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint ."
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description
Drop support for Node.js 6 and add Node.js 12 to CI.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-next/issues/3112

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
