### PR TITLE
Add a test to verify PersistedModel updateAll

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "http://loopback.io",
   "dependencies": {
     "loopback-datasource-juggler": "^3.0.0",
-    "strong-remoting": "^3.0.0"
+    "strong-remoting": "^3.15.0"
   },
   "devDependencies": {
     "assert": "^1.4.1",

--- a/test/remote-models.test.js
+++ b/test/remote-models.test.js
@@ -373,4 +373,17 @@ describe('Remote model tests', function() {
         });
     }
   });
+
+  describe('Model.updateAll([where], [data])', () => {
+    it('returns the count of updated instances in data source', async () => {
+      await ServerModel.create({first: 'baby', age: 1});
+      await ServerModel.create({first: 'grandma', age: 80});
+
+      const result = await ClientModel.updateAll(
+        {age: {lt: 6}},
+        {last: 'young'},
+      );
+      assert.deepEqual(result, {count: 1});
+    });
+  });
 });


### PR DESCRIPTION
Verify that `PersisteModel.updateAll` can be invoked and the remoting layer correctly deals with the `{count: number}` return type.

#### Related issues

See https://github.com/strongloop/loopback/issues/3717

This PR requires https://github.com/strongloop/strong-remoting/pull/472 to make the new test pass.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
