### PR TITLE
chore: update copyright year

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014,2018. All Rights Reserved.
+// Copyright IBM Corp. 2014,2019. All Rights Reserved.
 // Node module: loopback-connector-remote
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/relations.js
+++ b/lib/relations.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014,2018. All Rights Reserved.
+// Copyright IBM Corp. 2014,2019. All Rights Reserved.
 // Node module: loopback-connector-remote
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/remote-connector.js
+++ b/lib/remote-connector.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014,2018. All Rights Reserved.
+// Copyright IBM Corp. 2014,2019. All Rights Reserved.
 // Node module: loopback-connector-remote
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016,2018. All Rights Reserved.
+// Copyright IBM Corp. 2016,2019. All Rights Reserved.
 // Node module: loopback-connector-remote
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/integration/promise-support.js
+++ b/test/integration/promise-support.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016,2018. All Rights Reserved.
+// Copyright IBM Corp. 2016,2019. All Rights Reserved.
 // Node module: loopback-connector-remote
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/models-define-type.test.js
+++ b/test/models-define-type.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: loopback-connector-remote
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/models.test.js
+++ b/test/models.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016,2018. All Rights Reserved.
+// Copyright IBM Corp. 2016,2019. All Rights Reserved.
 // Node module: loopback-connector-remote
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/remote-connector.test.js
+++ b/test/remote-connector.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014,2018. All Rights Reserved.
+// Copyright IBM Corp. 2014,2019. All Rights Reserved.
 // Node module: loopback-connector-remote
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/remote-models.test.js
+++ b/test/remote-models.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016,2018. All Rights Reserved.
+// Copyright IBM Corp. 2016,2019. All Rights Reserved.
 // Node module: loopback-connector-remote
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT


### PR DESCRIPTION

Related: strongloop-internal/scrum-apex#440

Update the copyrights year in the rest of the packages besides #4596.

The changes are introduced by running the `slt copyright` command. 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-remote) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
